### PR TITLE
Fixing ImageList Go code

### DIFF
--- a/engine/api/sdk/examples.md
+++ b/engine/api/sdk/examples.md
@@ -471,7 +471,7 @@ func main() {
 		panic(err)
 	}
 
-	images, err := cli.ImageList(context.Background(), types.ImageListOptions{})
+	images, err := cli.ImageList(ctx, types.ImageListOptions{})
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Original: on line 18 we have `images, err := cli.ImageList(context.Background(), types.ImageListOptions{})` which gives us an error of:

```
# command-line-arguments
./main.go:12:2: ctx declared but not used
```

*Fix:* on line 18 we need to have `images, err := cli.ImageList(ctx, types.ImageListOptions{})`

<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

<!--Tell us what you did and why-->

### Unreleased project version (optional)

<!--If this change only applies to an unreleased version of a project, note
    that here and base your work on the `vnext-` branch for your project. If
    this doesn't apply to this PR, you can remove this whole section.
    Set a milestone if appropriate. -->

### Related issues (optional)

<!--Refer to related PRs or issues: #1234, or 'Fixes #1234' or 'Closes #1234'.
    Or link to full URLs to issues or pull requests in other Github projects -->
